### PR TITLE
Fail put/putIfAbsent ttl variants with UnsupportedOperationException

### DIFF
--- a/src/main/asciidoc/java/index.adoc
+++ b/src/main/asciidoc/java/index.adoc
@@ -27,7 +27,7 @@ Alternatively, you can configure the following system property to instruct vert.
 
 ### Using Vert.x from command line
 
-`vertx-ignite-3.3.3.jar` should be in the `lib` directory of the Vert.x installation.
+`vertx-ignite-3.4.0-SNAPSHOT.jar` should be in the `lib` directory of the Vert.x installation.
 
 ### Using Vert.x in Maven or Gradle project
 
@@ -40,7 +40,7 @@ Add a dependency to the artifact.
 <dependency>
   <groupId>io.vertx</groupId>
   <artifactId>vertx-ignite</artifactId>
-  <version>3.3.3</version>
+  <version>3.4.0-SNAPSHOT</version>
 </dependency>
 ----
 
@@ -48,7 +48,7 @@ Add a dependency to the artifact.
 
 [source,groovy,subs="+attributes"]
 ----
-compile 'io.vertx:vertx-ignite:3.3.3'
+compile 'io.vertx:vertx-ignite:3.4.0-SNAPSHOT'
 ----
 
 ### Programmatically specifying cluster manager

--- a/src/main/java/io/vertx/spi/cluster/ignite/IgniteClusterManager.java
+++ b/src/main/java/io/vertx/spi/cluster/ignite/IgniteClusterManager.java
@@ -55,9 +55,7 @@ import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
-import static org.apache.ignite.events.EventType.EVT_NODE_FAILED;
-import static org.apache.ignite.events.EventType.EVT_NODE_JOINED;
-import static org.apache.ignite.events.EventType.EVT_NODE_LEFT;
+import static org.apache.ignite.events.EventType.*;
 
 /**
  * Apache Ignite based cluster manager.

--- a/src/test/java/io/vertx/test/core/IgniteClusterWideMapTest.java
+++ b/src/test/java/io/vertx/test/core/IgniteClusterWideMapTest.java
@@ -20,6 +20,8 @@ package io.vertx.test.core;
 import io.vertx.core.spi.cluster.ClusterManager;
 import io.vertx.spi.cluster.ignite.IgniteClusterManager;
 
+import static org.hamcrest.CoreMatchers.*;
+
 /**
  * @author Andrey Gura
  */
@@ -28,5 +30,27 @@ public class IgniteClusterWideMapTest extends ClusterWideMapTestDifferentNodes {
   @Override
   protected ClusterManager getClusterManager() {
     return new IgniteClusterManager();
+  }
+
+  @Override
+  public void testMapPutTtl() {
+    getVertx().sharedData().getClusterWideMap("unsupported", onSuccess(map -> {
+      map.put("k", "v", 13L, onFailure(cause -> {
+        assertThat(cause, instanceOf(UnsupportedOperationException.class));
+        testComplete();
+      }));
+    }));
+    await();
+  }
+
+  @Override
+  public void testMapPutIfAbsentTtl() {
+    getVertx().sharedData().getClusterWideMap("unsupported", onSuccess(map -> {
+      map.putIfAbsent("k", "v", 13L, onFailure(cause -> {
+        assertThat(cause, instanceOf(UnsupportedOperationException.class));
+        testComplete();
+      }));
+    }));
+    await();
   }
 }


### PR DESCRIPTION
Ignite does not support this and the current implementations does not let you know.

It seems there was a misunderstanding about the ttl parameter goal.
It is not  a timeout for the cache operation, but the lifespan for this specific cache entry.
